### PR TITLE
[BrowserAPI Playground] Add separate pages for each integration type with basic recipes for modal search

### DIFF
--- a/examples/browser-api-playground/public/index.html
+++ b/examples/browser-api-playground/public/index.html
@@ -24,7 +24,7 @@
     -->
     <title>Browser API Playground</title>
     <script
-      src="https://canary.glean.com/embedded-search-latest.min.js"
+      src="https://app.glean.com/embedded-search-latest.min.js"
       id="external-js"
     ></script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/examples/browser-api-playground/public/index.html
+++ b/examples/browser-api-playground/public/index.html
@@ -24,7 +24,7 @@
     -->
     <title>Browser API Playground</title>
     <script
-      src="https://app.glean.com/embedded-search-latest.min.js"
+      src="https://canary.glean.com/embedded-search-latest.min.js"
       id="external-js"
     ></script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/examples/browser-api-playground/src/EmbedConfigContext.ts
+++ b/examples/browser-api-playground/src/EmbedConfigContext.ts
@@ -1,6 +1,8 @@
 import { createContext } from "react";
 import { AuthType, EmbeddedSearchWidget } from "./types";
 
+const makeValuesUndefined = (obj: Object) => Object.fromEntries(Object.entries(obj).map(([key]) => ([key])))
+
 const baseOptions = {
     authToken: undefined,
     backend: undefined,
@@ -11,7 +13,7 @@ const baseOptions = {
     locale: undefined,
     themeVariant: 'auto',
     theme: {},
-    webAppUrl: "https://canary.glean.com"
+    webAppUrl: undefined
 }
 
 const searchOptons = {
@@ -55,10 +57,8 @@ export const defaultConfig = {
         showInlineSearchBox: false,
     },
     [EmbeddedSearchWidget.Chat]: {
-        customizations: {
-            container: boxOptions,
-        },
-        initialMessage: "Who can I ask about Embedded Search", 
+        customizations: { container: makeValuesUndefined(boxOptions) },
+        initialMessage: undefined,
     },
 }
 

--- a/examples/browser-api-playground/src/components/Layout/Header.tsx
+++ b/examples/browser-api-playground/src/components/Layout/Header.tsx
@@ -1,14 +1,99 @@
-import { NavLink } from "react-router-dom";
-import SearchBox from "../SearchBox";
+import { Menu, MenuProps, Layout } from "antd";
 import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import SettingsDrawer from "../SettingsDrawer";
+
+const items: MenuProps['items'] = [
+  {
+    label: 'Home',
+    key: '/',
+  },
+  {
+    label: 'Autocomplete with search results',
+    key: '/search',
+  },
+  {
+    label: 'Chat',
+    key: '/chat',
+  },
+  {
+    label: 'Modal search',
+    key: '/modal-search',
+  },
+];
+
+const App: React.FC = () => {
+  const [current, setCurrent] = useState('mail');
+
+  const onClick: MenuProps['onClick'] = (e) => {
+    console.log('click ', e);
+    setCurrent(e.key);
+  };
+
+  return <Menu onClick={onClick} selectedKeys={[current]} mode="horizontal" items={items} />;
+};
+
 
 const Header = () => {
   const [settingsOpen, setSettingsOpen] = useState(false)
-  
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+ 
+  const onClick: MenuProps['onClick'] = (e) => navigate(e.key);
+
+  return (
+    <Layout.Header className="bg-white w-full flex items-center flex-grow-0 px-4 w-fixed w-full flex-shrink flex-grow-0 px-4 border-b border-gray-20 shadow-md">
+      <Menu
+        mode="horizontal"
+        defaultSelectedKeys={[pathname]}
+        items={items}
+        onClick={onClick}
+      />
+      <button onClick={() => setSettingsOpen(true)} className="ml-auto">
+        <svg 
+          xmlns="http://www.w3.org/2000/svg" 
+          width="24" 
+          height="24" 
+          viewBox="0 0 24 24" 
+          fill="none" 
+          stroke="currentColor" 
+          strokeWidth="2" 
+          strokeLinecap="round" 
+          strokeLinejoin="round" 
+          className="feather feather-settings"
+        >
+          <circle cx="12" cy="12" r="3"></circle>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+        </svg>
+      </button>
+      <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)}/>
+    </Layout.Header>
+  )
+
   return <header>
     <nav className="bg-white border-gray-200 px-4 lg:px-6 py-2.5 dark:bg-gray-800 z-50">
-      <div className="flex flex-wrap justify-between items-center mx-auto max-w-screen-xl">
+      <Menu onClick={onClick} selectedKeys={[pathname]} mode="horizontal" items={items} />
+      <li>
+        <button onClick={() => setSettingsOpen(true)}>
+          <svg 
+            xmlns="http://www.w3.org/2000/svg" 
+            width="24" 
+            height="24" 
+            viewBox="0 0 24 24" 
+            fill="none" 
+            stroke="currentColor" 
+            strokeWidth="2" 
+            strokeLinecap="round" 
+            strokeLinejoin="round" 
+            className="feather feather-settings"
+          >
+            <circle cx="12" cy="12" r="3"></circle>
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+          </svg>
+        </button>
+        <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)}/>
+      </li>
+      {/* <div className="flex flex-wrap justify-between items-center mx-auto max-w-screen-xl">
         <NavLink to="/" className="flex items-center">
           <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
             Example
@@ -35,30 +120,11 @@ const Header = () => {
                 </svg>
               </NavLink>
             </li>
-            <li>
-              <button onClick={() => setSettingsOpen(true)}>
-                <svg 
-                  xmlns="http://www.w3.org/2000/svg" 
-                  width="24" 
-                  height="24" 
-                  viewBox="0 0 24 24" 
-                  fill="none" 
-                  stroke="currentColor" 
-                  strokeWidth="2" 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  className="feather feather-settings"
-                >
-                  <circle cx="12" cy="12" r="3"></circle>
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-                </svg>
-              </button>
-              <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)}/>
-            </li>
+            
           </ul>
         </div>
-        <SearchBox />
-      </div>
+        <SearchBox /> */}
+      {/* </div> */}
     </nav>
   </header>
 };

--- a/examples/browser-api-playground/src/components/Layout/Header.tsx
+++ b/examples/browser-api-playground/src/components/Layout/Header.tsx
@@ -9,12 +9,12 @@ const items: MenuProps['items'] = [
     key: '/',
   },
   {
-    label: 'Autocomplete with search results',
-    key: '/search',
-  },
-  {
     label: 'Chat',
     key: '/chat',
+  },
+  {
+    label: 'Autocomplete with search results',
+    key: '/search',
   },
   {
     label: 'Modal search',
@@ -69,64 +69,6 @@ const Header = () => {
       <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)}/>
     </Layout.Header>
   )
-
-  return <header>
-    <nav className="bg-white border-gray-200 px-4 lg:px-6 py-2.5 dark:bg-gray-800 z-50">
-      <Menu onClick={onClick} selectedKeys={[pathname]} mode="horizontal" items={items} />
-      <li>
-        <button onClick={() => setSettingsOpen(true)}>
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
-            strokeLinejoin="round" 
-            className="feather feather-settings"
-          >
-            <circle cx="12" cy="12" r="3"></circle>
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
-          </svg>
-        </button>
-        <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)}/>
-      </li>
-      {/* <div className="flex flex-wrap justify-between items-center mx-auto max-w-screen-xl">
-        <NavLink to="/" className="flex items-center">
-          <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
-            Example
-          </span>
-        </NavLink>
-        <div
-          className="hidden justify-between items-center w-full lg:flex lg:w-auto lg:order-1 gap-2"
-          id="mobile-menu-2"
-        >
-          <ul className="flex flex-col mt-4 font-medium lg:flex-row lg:space-x-8 lg:mt-0">
-            <li>
-              <NavLink
-                to="/chat"
-                className="block py-2 pr-4 pl-3 text-gray-700 border-b border-gray-100 hover:bg-gray-50 lg:hover:bg-transparent lg:border-0 lg:hover:text-primary-700 lg:p-0 dark:text-gray-400 lg:dark:hover:text-white dark:hover:bg-gray-700 dark:hover:text-white lg:dark:hover:bg-transparent dark:border-gray-700 flex items-center gap-2"
-              >
-                Chat
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M11.293 4.707 17.586 11H4v2h13.586l-6.293 6.293 1.414 1.414L21.414 12l-8.707-8.707-1.414 1.414z" />
-                </svg>
-              </NavLink>
-            </li>
-            
-          </ul>
-        </div>
-        <SearchBox /> */}
-      {/* </div> */}
-    </nav>
-  </header>
 };
 
 export default Header;

--- a/examples/browser-api-playground/src/components/Layout/Header.tsx
+++ b/examples/browser-api-playground/src/components/Layout/Header.tsx
@@ -22,18 +22,6 @@ const items: MenuProps['items'] = [
   },
 ];
 
-const App: React.FC = () => {
-  const [current, setCurrent] = useState('mail');
-
-  const onClick: MenuProps['onClick'] = (e) => {
-    console.log('click ', e);
-    setCurrent(e.key);
-  };
-
-  return <Menu onClick={onClick} selectedKeys={[current]} mode="horizontal" items={items} />;
-};
-
-
 const Header = () => {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { pathname } = useLocation()

--- a/examples/browser-api-playground/src/components/Layout/PageLayout.tsx
+++ b/examples/browser-api-playground/src/components/Layout/PageLayout.tsx
@@ -9,7 +9,7 @@ const PageLayout = ({ children }: PropsWithChildren) => {
   const contextValue = useConfigStore()
 
   return <EmbedConfigContext.Provider value={contextValue}>
-    <Layout className="h-full">
+    <Layout className="h-full w-full">
       <Header />
       <Content role="main" className="w-full flex-auto bg-white">
         {children}

--- a/examples/browser-api-playground/src/components/Layout/PageLayout.tsx
+++ b/examples/browser-api-playground/src/components/Layout/PageLayout.tsx
@@ -2,21 +2,19 @@ import { PropsWithChildren } from "react";
 import Header from "./Header";
 import { EmbedConfigContext } from "../../EmbedConfigContext";
 import useConfigStore from "../../useConfigStore";
+import { Layout } from "antd";
+import { Content } from "antd/es/layout/layout";
 
 const PageLayout = ({ children }: PropsWithChildren) => {
   const contextValue = useConfigStore()
 
   return <EmbedConfigContext.Provider value={contextValue}>
-    <div className="w-full h-full flex flex-col items-center">
-      <div className="w-fixed w-full flex-shrink flex-grow-0 px-4 w-fixed w-full flex-shrink flex-grow-0 px-4 border-b border-gray-20 shadow-md">
-        <div className="sticky top-0 p-4 w-full h-full z-50">
-          <Header />
-        </div>
-      </div>
-      <main role="main" className="w-full flex-auto">
+    <Layout className="h-full">
+      <Header />
+      <Content role="main" className="w-full flex-auto bg-white">
         {children}
-      </main>
-    </div>
+      </Content>
+    </Layout>
   </EmbedConfigContext.Provider>
 };
 

--- a/examples/browser-api-playground/src/components/NativeSearchBox.tsx
+++ b/examples/browser-api-playground/src/components/NativeSearchBox.tsx
@@ -14,6 +14,7 @@ const NativeSearchBox = () => {
       ...config[baseOptionsKey],
       ...config[searchOptionsKey],
     }
+
     window.EmbeddedSearch.attach(containerRef.current, {
       ...NativeSearchBoxCustomConfig,
       ...authParams,

--- a/examples/browser-api-playground/src/components/SearchBox.tsx
+++ b/examples/browser-api-playground/src/components/SearchBox.tsx
@@ -60,7 +60,7 @@ const SearchBox = () => {
       ref={containerRef}
       style={{
         height: "48px",
-        width: "600px",
+        width: "100%",
         position: "relative", // This is required
         zIndex: 2, // Should be higher than other elements below
       }}

--- a/examples/browser-api-playground/src/components/SettingsDrawer.tsx
+++ b/examples/browser-api-playground/src/components/SettingsDrawer.tsx
@@ -1,71 +1,120 @@
-import { useCallback, useContext, useLayoutEffect, useMemo, useState } from 'react'
-import ReactJsonView, { InteractionProps } from 'react-json-view'
-import { ConfigType, EmbedConfigContext, defaultConfig } from '../EmbedConfigContext'
-import { Button, Drawer, Tooltip, message } from 'antd'
-import { CopyOutlined, ReloadOutlined } from '@ant-design/icons'
+import {
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
+import ReactJsonView, { InteractionProps } from "react-json-view";
+import {
+  ConfigType,
+  EmbedConfigContext,
+  defaultConfig,
+} from "../EmbedConfigContext";
+import { Button, Drawer, Tooltip, message } from "antd";
+import { CopyOutlined, ReloadOutlined } from "@ant-design/icons";
 
 interface SettingsDrawerProps {
-    open: boolean
-    onClose: () => void
+  open: boolean;
+  onClose: () => void;
 }
 
-const SettingsDrawer = ({open, onClose}: SettingsDrawerProps) => {
-    const {config, setConfig} = useContext(EmbedConfigContext)
-    const [draftConfig, setDraftConfig] = useState<ConfigType>(config) 
-    
-    useLayoutEffect(() => {
-        setDraftConfig(config)
-    }, [config])
+const SettingsDrawer = ({ open, onClose }: SettingsDrawerProps) => {
+  const { config, setConfig } = useContext(EmbedConfigContext);
+  const [draftConfig, setDraftConfig] = useState<ConfigType>(config);
 
-    const handleReset = useCallback(() => setConfig(defaultConfig), [config])
-    const handleCopy = useCallback(() => {
-        navigator.clipboard.writeText(JSON.stringify(draftConfig))
-        message.success('Copied to clipboard')
-    }, [draftConfig])
-    
-    const handleJsonUpdate = useCallback((props: InteractionProps) => setDraftConfig(props.updated_src as ConfigType), [])
-    const handlePublish = useCallback(() => {
-        setConfig(draftConfig)
-        message.success('Sucessfully published')
-    }, [draftConfig])
-    const handleCancel = useCallback(() => setDraftConfig(config), [config])
+  useLayoutEffect(() => {
+    setDraftConfig(config);
+  }, [config]);
 
-    const isEditing = useMemo(() => config !== draftConfig, [config, draftConfig])
+  const handleReset = useCallback(() => setConfig(defaultConfig), [config]);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(JSON.stringify(draftConfig));
+    message.success("Copied to clipboard");
+  }, [draftConfig]);
 
-    return (
-    <Drawer 
-        title={<div style={{display: 'inline-flex', width: '100%', justifyContent: 'space-between', alignItems: 'center'}}>
-                Settings{' '}
-                <div style={{display: 'inline-flex', columnGap: '20px', marginRight: 30}}>
-                    <Tooltip title="Reset to default" placement="top"><ReloadOutlined onClick={handleReset}/></Tooltip>
-                    <Tooltip title="Copy as JSON" placement="top"><CopyOutlined onClick={handleCopy}/></Tooltip>
-                </div>
-            </div>} 
-        mask={false} 
-        placement="right" 
-        onClose={onClose} 
-        open={open}
-        width={500}
+  const handleJsonUpdate = useCallback(
+    (props: InteractionProps) =>
+      setDraftConfig(props.updated_src as ConfigType),
+    []
+  );
+  const handlePublish = useCallback(() => {
+    setConfig(draftConfig);
+    message.success("Sucessfully published");
+  }, [draftConfig]);
+  const handleCancel = useCallback(() => setDraftConfig(config), [config]);
+
+  const isEditing = useMemo(
+    () => config !== draftConfig,
+    [config, draftConfig]
+  );
+
+  return (
+    <Drawer
+      title={
+        <div
+          style={{
+            display: "inline-flex",
+            width: "100%",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          Settings{" "}
+          <div
+            style={{
+              display: "inline-flex",
+              columnGap: "20px",
+              marginRight: 30,
+            }}
+          >
+            <Tooltip title="Reset to default" placement="top">
+              <ReloadOutlined onClick={handleReset} />
+            </Tooltip>
+            <Tooltip title="Copy as JSON" placement="top">
+              <CopyOutlined onClick={handleCopy} />
+            </Tooltip>
+          </div>
+        </div>
+      }
+      mask={false}
+      placement="right"
+      onClose={onClose}
+      open={open}
+      width={500}
     >
-        <ReactJsonView 
-            name="Configurable Props" 
-            collapsed={1} 
-            defaultValue={undefined}
-            displayDataTypes 
-            displayObjectSize={false} 
-            onAdd={handleJsonUpdate}
-            onDelete={handleJsonUpdate}
-            onEdit={handleJsonUpdate}
-            src={draftConfig}
-            validationMessage=""
-        />
-        {isEditing && (
-            <div style={{display: 'inline-flex', columnGap: 25, marginTop: 20, float: 'right', marginRight: 30}}>
-                <Button size="middle" onClick={handleCancel}>Cancel</Button>
-                <Button size="middle" onClick={handlePublish}>Publish</Button>
-            </div>
-        )}
-    </Drawer>)
-}
+      <ReactJsonView
+        name="Configurable Props"
+        collapsed={1}
+        defaultValue={undefined}
+        displayDataTypes
+        displayObjectSize={false}
+        onAdd={handleJsonUpdate}
+        onDelete={handleJsonUpdate}
+        onEdit={handleJsonUpdate}
+        src={draftConfig}
+        validationMessage=""
+      />
+      {isEditing && (
+        <div
+          style={{
+            display: "inline-flex",
+            columnGap: 25,
+            marginTop: 20,
+            float: "right",
+            marginRight: 30,
+          }}
+        >
+          <Button size="middle" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button size="middle" onClick={handlePublish}>
+            Publish
+          </Button>
+        </div>
+      )}
+    </Drawer>
+  );
+};
 
-export default SettingsDrawer
+export default SettingsDrawer;

--- a/examples/browser-api-playground/src/index.tsx
+++ b/examples/browser-api-playground/src/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import PageLayout from "./components/Layout/PageLayout";
 import ChatPage from "./pages/ChatPage";
 import HomePage from "./pages/HomePage";
+import ModalSearch from "./pages/ModalSearch";
 import SearchResultsPage from "./pages/SearchResultsPage";
 
 import "./styles.css";
@@ -15,6 +16,7 @@ function App() {
         <Routes>
           <Route path="/search" element={<SearchResultsPage />} />
           <Route path="/chat" element={<ChatPage />} />
+          <Route path="/modal-search" element={<ModalSearch />} />
           <Route path="/" element={<HomePage />} />
         </Routes>
       </PageLayout>

--- a/examples/browser-api-playground/src/pages/HomePage.tsx
+++ b/examples/browser-api-playground/src/pages/HomePage.tsx
@@ -1,4 +1,3 @@
-import NativeSearchBox from "../components/NativeSearchBox";
 
 const HomePage = () => (
   <div>
@@ -8,32 +7,15 @@ const HomePage = () => (
           <div className="lg:w-2/3 mx-auto inline-flex" style={{justifyContent: 'space-between'}}>
             <div>
               <h2 className="text-xs text-indigo-500 tracking-widest font-medium title-font mb-1">
-                Glean Help Center
+                Glean Browser API Playground
               </h2>
               <h1 className="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">
-                Welcome
+              Welcome
               </h1>
             </div>
-            <NativeSearchBox />
           </div>
           <p className="lg:w-2/3 mx-auto leading-relaxed text-base">
-            <p>We're delighted to have you here, and we're committed to providing you the support and resources you need to make the most of our products and services.</p>
-            <br/>
-            <strong>Getting Started:</strong>
-            <p>Whether you're a new customer or have been with us for years, our Help Center is designed to answer all your questions. Here's what you'll find:</p>
-            <br/>
-            <ol style={{listStyle: 'revert'}}>
-                <li><strong>FAQs:</strong> A collection of answers to our most frequently asked questions. Whether you need help with account setup or troubleshooting a specific issue, you'll likely find your answer here.</li>
-                <li><strong>Guides and Tutorials:</strong> Step-by-step guides and video tutorials to help you get started with our products and services, or master more advanced features.</li>
-                <li><strong>Community Forums:</strong> Engage with other users, share your experiences, ask questions, and find solutions from our community of experts and fellow customers.</li>
-                <li><strong>Contact Us:</strong> Need personalized assistance? Reach out to our dedicated support team through phone, email, or live chat. We're here to help!</li>
-            </ol>
-            <br/>
-            <strong>Stay Updated:</strong>
-            <p>Be sure to check our updates section for the latest news, product releases, and enhancements. We regularly update our Help Center to make sure you have access to the most accurate and up-to-date information.</p>
-            <br/>
-            <strong>Conclusion:</strong>
-            <p>We are here to assist you every step of the way, so don't hesitate to explore our Help Center or reach out if you need anything. Thank you for choosing [Your Company Name], and we look forward to supporting your journey to success!</p>
+            <p>Navigate to each page matching a supported integration type and utilize the sidebar settings drawer to edit options directly.</p>
           </p>
         </div>
       </div>

--- a/examples/browser-api-playground/src/pages/HomePage.tsx
+++ b/examples/browser-api-playground/src/pages/HomePage.tsx
@@ -15,7 +15,8 @@ const HomePage = () => (
             </div>
           </div>
           <p className="lg:w-2/3 mx-auto leading-relaxed text-base">
-            <p>Navigate to each page matching a supported integration type and utilize the sidebar settings drawer to edit options directly.</p>
+            <p>Navigate to each page matching a supported integration type.</p>
+            <p>Utilize the sidebar settings drawer to edit options directly.</p>
           </p>
         </div>
       </div>

--- a/examples/browser-api-playground/src/pages/ModalSearch.tsx
+++ b/examples/browser-api-playground/src/pages/ModalSearch.tsx
@@ -1,0 +1,87 @@
+import { Divider, Input, Select, Typography } from "antd";
+import { useEffect, useState } from "react";
+import NativeSearchBox from "../components/NativeSearchBox";
+
+const Playground = () => (
+  <div>
+    <Typography.Paragraph> Basic NSR setup - configurable through sidebar(Options + SearchOptions)</Typography.Paragraph>
+    <NativeSearchBox />
+  </div>
+)
+
+const MultipleNSRAttachments = () => {
+  useEffect(() => {
+    document.querySelectorAll('input[data-form-input-type="github-search"]').forEach((element) => {
+      window.EmbeddedSearch.attach(element, {
+        datasourcesFilter: ['github'],
+        key: 'group-1',
+      })
+    })
+    document.querySelectorAll('input[data-form-input-type="jira-search"]').forEach((element) => {
+      window.EmbeddedSearch.attach(element, {
+        datasourcesFilter: ['jira'],
+        key: 'group-2',
+      })
+    })
+  }, [])
+
+  return (
+    <div>
+      <Typography.Title level={4}>Using Github as a datasource filter</Typography.Title>
+      <Input data-form-input-type='github-search' type='search' placeholder="Search..." className="mb-4" />
+      <Input data-form-input-type='github-search' type='search' placeholder="Search..." className="mb-4" />
+      <Typography.Title level={4} >Using JIRA as a datasource filter</Typography.Title>
+      <Input data-form-input-type='jira-search' type='search' placeholder="Search..." className="" />
+    </div>
+  )
+}
+
+const BasicNSR = () => {
+
+  useEffect(() => {
+    window.EmbeddedSearch.attach(document.getElementById('basic-nsr-target'))
+  }, [])
+
+  return <Input id='basic-nsr-target' type='search' placeholder="Search..."/>
+}
+
+/**
+ * A naive id generator
+ */
+const withId = (item: any, index: number) => ({ id: item.title.replace(/[^a-zA-Z0-9 ]/g, ""), ...item })
+
+const allScenes = [
+  { title: 'Modal search playground', renderer: Playground },
+  { title: 'Modal search without any configuration', renderer: BasicNSR },
+  { title: 'Multiple modal search attachments in the same page', renderer: MultipleNSRAttachments },
+].map(withId)
+
+const ModalSearch = () => {
+  // Note: Title is usually not a great idea, but should be okay here
+  const [activeSceneId, setActiveSceneId] = useState(allScenes[0].id)
+  
+  const activeScene = allScenes.find(scene => scene.id === activeSceneId)
+  const { renderer: Renderer, title } = activeScene
+
+  return (
+    <div className="w-full m-auto">
+      <div className="bg-slate-200 p-8">
+        <Typography.Title level={3}>Native search replacement with Glean</Typography.Title>
+        <Typography.Title level={5}>Select a scene</Typography.Title>
+        <Typography.Paragraph>Scenes are pre-curated scenarios that can apply to specific use-cases</Typography.Paragraph>
+        <Select
+          style={{ width: '100%' }}
+          defaultValue={activeSceneId}
+          onChange={setActiveSceneId}
+          options={allScenes.map(scene => ({ value: scene.id, label: scene.title } ))}
+        />
+      </div>
+      <div className="p-8">
+        <Typography.Title level={3}>{title}</Typography.Title>
+        <Renderer />
+      </div>
+    </div>
+  )
+}
+
+export default ModalSearch;

--- a/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
+++ b/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import SearchBox from "../components/SearchBox";
 import { EmbedConfigContext, authOptionsKey, baseOptionsKey, searchOptionsKey } from "../EmbedConfigContext";
 import { EmbeddedSearchWidget } from "../types";
 import useAuthProvider from "../useAuthProvider";
@@ -52,15 +53,20 @@ const SearchResults = () => {
   }, [query, handleSearch, handleChat, config, authParams]);
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        height: "100%",
-        width: "100%",
-        position: "relative",
-        paddingTop: "24px",
-      }}
-    />
+    <div>
+      <div className="pt-8 max-w-screen-xl m-auto">
+        <SearchBox />
+      </div>
+      <div
+        ref={containerRef}
+        style={{
+          height: "100%",
+          width: "100%",
+          position: "relative",
+          paddingTop: "24px",
+        }}
+      />
+    </div>
   );
 };
 

--- a/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
+++ b/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
@@ -53,7 +53,7 @@ const SearchResults = () => {
   }, [query, handleSearch, handleChat, config, authParams]);
 
   return (
-    <div>
+    <div className="h-full">
       <div className="pt-8 max-w-screen-xl m-auto">
         <SearchBox />
       </div>

--- a/examples/browser-api-playground/src/useConfigStore.ts
+++ b/examples/browser-api-playground/src/useConfigStore.ts
@@ -1,13 +1,13 @@
 import { useCallback, useMemo, useState } from "react";
 import { ConfigType, baseOptionsKey, defaultConfig } from "./EmbedConfigContext";
-import _ from "lodash";
+import { merge } from "lodash";
 
 const storeKey = "embedded-search-config";
 
 const useConfigStore = () => {
     const [config, setConfig] = useState<ConfigType>(() => {
         const value = window.sessionStorage.getItem(storeKey)
-        return value ? _.merge(defaultConfig, JSON.parse(value)) : defaultConfig
+        return value ? merge(defaultConfig, JSON.parse(value)) : defaultConfig
     });
 
     const setPersistentConfig = useCallback((newValue: ConfigType) => setConfig((prevValue: ConfigType) => {


### PR DESCRIPTION
Also refactors some layout options.

Proposed format per page:
- Recipe selector (with the built-in playground as the first option)
- Other hardcoded / manually curated recipes for custom use-cases

https://github.com/askscio/glean-browser-api/assets/108234710/f60d265f-6e91-4342-866b-8e61bf3da5f4

