### PR TITLE
Remove default empty `onAuthTokenRequired`

### DIFF
--- a/examples/browser-api-playground/src/useAuthProvider.ts
+++ b/examples/browser-api-playground/src/useAuthProvider.ts
@@ -2,12 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { AuthOptions, AuthType } from "./types";
 
 interface AuthState {
-  onAuthTokenRequired: () => void;
+  onAuthTokenRequired?: () => void;
   authToken?: any;
 }
 
 const defaultAuthState: AuthState = {
-  onAuthTokenRequired: () => {},
 };
 
 const serverBasePath = (() => {


### PR DESCRIPTION
`onAuthTokenRequired` should only be provided for server-driven-auth