### PR TITLE
Support inputting API Key from client

### DIFF
--- a/examples/browser-api-playground/server.js
+++ b/examples/browser-api-playground/server.js
@@ -4,23 +4,21 @@ const axios = require("axios");
 
 const app = express();
 const port = 8585;
-// During local development, set the API_SECRET environment variable
-const authorizationToken = process.env.API_SECRET;
 
 app.use(express.json());
 app.use(cors());
 
 app.post("/generateAuthToken", (req, res) => {
   // Extract the backend and user from the request
-  const { backend, actAs } = req.body;
+  const { backend, actAs, apiKey } = req.body;
 
   // Call the Glean server's createauthtoken endpoint
   axios({
     method: "POST",
     url: `${backend}/rest/api/v1/createauthtoken`,
     headers: {
-      Authorization: `Bearer ${authorizationToken}`,
-      "X-Scio-Actas": actAs || "steve.smith@salessavvy.net",
+      Authorization: `Bearer ${apiKey}`,
+      "X-Scio-Actas": actAs,
       accept: "application/json",
     },
   })
@@ -36,10 +34,6 @@ app.post("/generateAnonymousAuthToken", (req, res) => {
   axios({
     method: "post",
     url: `${backend}/api/v1/createanonymoustoken`,
-    headers: {
-      Authorization: `Bearer ${authorizationToken}`,
-      "X-Scio-Actas": actAs,
-    },
   })
     .then((response) => res.json(response.data))
     .catch((error) => res.status(500).json({ error: error.message }));

--- a/examples/browser-api-playground/src/EmbedConfigContext.ts
+++ b/examples/browser-api-playground/src/EmbedConfigContext.ts
@@ -37,6 +37,7 @@ export const defaultConfig = {
     [authOptionsKey]: {
         type: AuthType.Default,
         actAs: undefined,
+        apiKey: undefined,
     },
     [baseOptionsKey]: baseOptions,
     [searchOptionsKey]: searchOptons,

--- a/examples/browser-api-playground/src/types.ts
+++ b/examples/browser-api-playground/src/types.ts
@@ -7,6 +7,7 @@ export const enum AuthType {
 export interface AuthOptions {
     type: AuthType;
     actAs?: string;
+    apiKey?: string;
 }
   
 export const enum EmbeddedSearchWidget {

--- a/examples/browser-api-playground/src/useAuthProvider.ts
+++ b/examples/browser-api-playground/src/useAuthProvider.ts
@@ -29,7 +29,11 @@ const fetchTokenFromServer = async (
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ backend, actAs: authOptions.actAs }),
+      body: JSON.stringify({ 
+        backend, 
+        actAs: authOptions.actAs, 
+        apiKey: authOptions.apiKey,
+      }),
     })
       .then((response) => response.json())
       .then((data) => resolve(data))


### PR DESCRIPTION
It would facilitate QA to easily configure the API Key from the client itself. Currently, they need to visit Codesanbox to update this key.

![Screenshot 2024-04-30 at 12 07 41 PM](https://github.com/askscio/glean-browser-api/assets/108983957/b8352c0c-334e-4648-ba0f-cf4b3e5b0b12)
