### PR TITLE
Add types package and authMethod support

### DIFF
--- a/examples/browser-api-playground/package.json
+++ b/examples/browser-api-playground/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@gleanwork/web-sdk": "1.0.1",
     "@types/lodash": "^4.14.197",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",

--- a/examples/browser-api-playground/src/EmbedConfigContext.ts
+++ b/examples/browser-api-playground/src/EmbedConfigContext.ts
@@ -1,9 +1,11 @@
 import { createContext } from "react";
-import { AuthType, EmbeddedSearchWidget } from "./types";
+import { AuthType, BaseOptions, EmbeddedSearchWidget } from "./types";
 
 const makeValuesUndefined = (obj: Object) => Object.fromEntries(Object.entries(obj).map(([key]) => ([key])))
 
-const baseOptions = {
+const baseOptions: BaseOptions = {
+    authMethod: undefined,
+    onAuthTokenRequired: undefined,
     authToken: undefined,
     backend: undefined,
     disableAnalytics: false,

--- a/examples/browser-api-playground/src/components/NativeSearchBox.tsx
+++ b/examples/browser-api-playground/src/components/NativeSearchBox.tsx
@@ -5,7 +5,7 @@ import useAuthProvider from "../useAuthProvider";
 const NativeSearchBox = () => {
   const containerRef = useRef(null);
   const {config} = useContext(EmbedConfigContext)
-  const authParams = useAuthProvider(config[authOptionsKey], config[baseOptionsKey].backend)
+  const authParams = useAuthProvider()
 
   useEffect(() => {
     if (!window.EmbeddedSearch) return;

--- a/examples/browser-api-playground/src/components/SearchBox.tsx
+++ b/examples/browser-api-playground/src/components/SearchBox.tsx
@@ -9,7 +9,7 @@ const SearchBox = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const {config} = useContext(EmbedConfigContext)
-  const authParams = useAuthProvider(config[authOptionsKey], config[baseOptionsKey].backend)
+  const authParams = useAuthProvider()
 
   const query = searchParams.get("query") ?? "";
 
@@ -45,12 +45,15 @@ const SearchBox = () => {
       ...config[searchOptionsKey],
       ...config[EmbeddedSearchWidget.SearchBox]
     }
+
+    console.log('Search Box', authParams, searchBoxCustomConfig)
+
     window.EmbeddedSearch.renderSearchBox(containerRef.current, {
       onSearch: handleSearch,
       onChat: handleChat,
       query,
-      ...searchBoxCustomConfig,
       ...authParams,
+      ...searchBoxCustomConfig,
       // Add overrides to the custom config here
     });
   }, [handleChat, handleSearch, query, config, authParams]);

--- a/examples/browser-api-playground/src/components/SearchBox.tsx
+++ b/examples/browser-api-playground/src/components/SearchBox.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { EmbedConfigContext, authOptionsKey, baseOptionsKey, searchOptionsKey } from "../EmbedConfigContext";
+import { EmbedConfigContext, baseOptionsKey, searchOptionsKey } from "../EmbedConfigContext";
 import { EmbeddedSearchWidget } from "../types";
 import useAuthProvider from "../useAuthProvider";
 

--- a/examples/browser-api-playground/src/components/SearchBox.tsx
+++ b/examples/browser-api-playground/src/components/SearchBox.tsx
@@ -46,14 +46,12 @@ const SearchBox = () => {
       ...config[EmbeddedSearchWidget.SearchBox]
     }
 
-    console.log('Search Box', authParams, searchBoxCustomConfig)
-
     window.EmbeddedSearch.renderSearchBox(containerRef.current, {
       onSearch: handleSearch,
       onChat: handleChat,
       query,
-      ...authParams,
       ...searchBoxCustomConfig,
+      ...authParams,
       // Add overrides to the custom config here
     });
   }, [handleChat, handleSearch, query, config, authParams]);

--- a/examples/browser-api-playground/src/pages/ChatPage.tsx
+++ b/examples/browser-api-playground/src/pages/ChatPage.tsx
@@ -8,7 +8,7 @@ const ChatPage = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const {config} = useContext(EmbedConfigContext)
-  const authParams = useAuthProvider(config[authOptionsKey], config[baseOptionsKey].backend)
+  const authParams = useAuthProvider()
   const navigate = useNavigate()
 
   useEffect(() => {

--- a/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
+++ b/examples/browser-api-playground/src/pages/SearchResultsPage.tsx
@@ -9,7 +9,7 @@ const SearchResults = () => {
   const containerRef = useRef(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const {config} = useContext(EmbedConfigContext)
-  const authParams = useAuthProvider(config[authOptionsKey], config[baseOptionsKey].backend)
+  const authParams = useAuthProvider()
   const navigate = useNavigate();
 
   const query = searchParams.get("query") ?? "";

--- a/examples/browser-api-playground/src/types.ts
+++ b/examples/browser-api-playground/src/types.ts
@@ -1,3 +1,5 @@
+import type { Options } from '@gleanwork/web-sdk'
+
 export const enum AuthType {
     Default = 'default',
     ServerSide = 'server-side',
@@ -15,3 +17,6 @@ export const enum EmbeddedSearchWidget {
     SearchResults = 'Search Results',
     Chat = 'Chat',
 } 
+
+// TODO: Remove authMethod when types package is updated
+export type BaseOptions = Options & { authMethod?: 'sso' | 'token'}

--- a/examples/browser-api-playground/src/useAuthProvider.ts
+++ b/examples/browser-api-playground/src/useAuthProvider.ts
@@ -53,7 +53,7 @@ const useAuthProvider = () => {
      * before storing in session/local storage
      */
     if (authMethod === 'token') {
-      config[baseOptionsKey].onAuthTokenRequired = () => {}
+      defaultAuthState.onAuthTokenRequired = () => {}
     }
     return defaultAuthState
   });

--- a/examples/browser-api-playground/src/useConfigStore.ts
+++ b/examples/browser-api-playground/src/useConfigStore.ts
@@ -24,16 +24,18 @@ const shouldReload = (prevValue: ConfigType, newValue: ConfigType) => {
 const useConfigStore = () => {
     const [config, setConfig] = useState<ConfigType>(() => {
         const value = window.sessionStorage.getItem(storeKey)
-        return value ? merge({}, defaultConfig, JSON.parse(value)) : defaultConfig
+        if (!value) return defaultConfig
+        return JSON.parse(value)
     });
 
     const setPersistentConfig = useCallback((newValue: ConfigType) => setConfig((prevValue: ConfigType) => {
-        window.sessionStorage.setItem(storeKey, JSON.stringify(newValue));
+        const updatedConfig = merge({}, config, newValue)
+        window.sessionStorage.setItem(storeKey, JSON.stringify(updatedConfig));
         // Reload page if backend URL or webAppUrl changes
-        if (shouldReload(prevValue, newValue)) {
+        if (shouldReload(prevValue, updatedConfig)) {
             window.location.reload();
         }
-        return newValue;
+        return updatedConfig;
     }), [setConfig]);
 
     window.setConfig = setPersistentConfig;

--- a/examples/browser-api-playground/yarn.lock
+++ b/examples/browser-api-playground/yarn.lock
@@ -1457,6 +1457,11 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz"
   integrity sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==
 
+"@gleanwork/web-sdk@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@gleanwork/web-sdk/-/web-sdk-1.0.1.tgz#7ee006de9cf0ffcbca3014f826ce728166c0ee76"
+  integrity sha512-iuCIZQfjUQRL9VBUlDrZhTe5K9x8hmfWFMaUW/ByBWRwAT1u+SKCAGwkhu2/N4egC7VvsFgQcXExh/QpU+o17A==
+
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz"


### PR DESCRIPTION
- Add typings package and use for `Options`
- Add support for `authMethod`
- Set `onAuthTokenRequired` if `authMethod="token"` for QA automations
- Single source for config instead of merging sessionStorage + default, either sessionStorage or default. There were also cases where if mandatory properties(used in `shouldReload` like `'backend', 'webAppUrl'`) are skipped setting config breaks so merging before setting. LMK if this has concerns  


https://github.com/askscio/glean-browser-api/assets/150239672/1c97759c-b786-4a84-be39-ef3454530a46

