### PR TITLE
Remove deprecated @babel/plugin-proposal-private-property-in-object

### DIFF
--- a/examples/browser-api-playground/package.json
+++ b/examples/browser-api-playground/package.json
@@ -22,7 +22,6 @@
     "react-virtualized-auto-sizer": "1.0.9"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/lodash": "^4.14.197",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",

--- a/examples/browser-api-playground/pnpm-lock.yaml
+++ b/examples/browser-api-playground/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
         specifier: 1.0.9
         version: 1.0.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
-      '@babel/plugin-proposal-private-property-in-object':
-        specifier: ^7.21.11
-        version: 7.21.11(@babel/core@7.28.0)
       '@types/lodash':
         specifier: ^4.14.197
         version: 4.17.20


### PR DESCRIPTION
Not used and pnpm commands show deprecation message.