### PR TITLE
fix: ensure tasks that restart on resume do not require a rebuild

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -2,16 +2,19 @@
   // These tasks will run in order when initializing your CodeSandbox project.
   "setupTasks": [
     {
-      "name": "cd examples/browser-api-playground",
-      "command": "cd examples/browser-api-playground"
+      "name": "initialize",
+      "command": "cd examples/browser-api-playground && pnpm i && pnpm build"
     }
   ],
-
   // These tasks can be run from CodeSandbox. Running one will open a log in the app.
   "tasks": {
+    "Setup": {
+      "name": "Setup",
+      "command": "cd examples/browser-api-playground && pnpm i && pnpm build"
+    },
     "FE Server": {
       "name": "FE Server",
-      "command": "cd examples/browser-api-playground && pnpm i && pnpm start:client",
+      "command": "cd examples/browser-api-playground && pnpm start:client",
       "runAtStart": true,
       "preview": {
         "port": 3000
@@ -19,7 +22,7 @@
     },
     "BE Server": {
       "name": "BE Server",
-      "command": "cd examples/browser-api-playground && pnpm i && pnpm start:server",
+      "command": "cd examples/browser-api-playground && pnpm start:server",
       "runAtStart": true,
       "preview": {
         "port": 8585

--- a/examples/browser-api-playground/package.json
+++ b/examples/browser-api-playground/package.json
@@ -28,7 +28,7 @@
     "typescript": "4.4.2"
   },
   "scripts": {
-    "start:client": "pnpm build && node webserver.js",
+    "start:client": "node webserver.js",
     "start:server": "node server.js",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",


### PR DESCRIPTION
Context: I'm noticing that the server is crashing infrequently and subsequently doing a full rebuild on restart. This doesn't solve the former but might help speed up the restart.