### PR TITLE
Add select for SDK source

### DIFF
--- a/examples/browser-api-playground/src/components/Layout/Header.tsx
+++ b/examples/browser-api-playground/src/components/Layout/Header.tsx
@@ -29,7 +29,6 @@ const Header = () => {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { pathname } = useLocation()
   const navigate = useNavigate()
- 
   const onClick: MenuProps['onClick'] = (e) => navigate(e.key);
 
   return (
@@ -39,21 +38,43 @@ const Header = () => {
         selectedKeys={[pathname]}
         items={items}
         onClick={onClick}
-        style={{width: '100%'}}
+        style={{width: '85%'}}
       />
-      <div style={{display: "flex", lineHeight: "16px"}}>
-        <span>current sdk source: {contextValue.config?.[sdkOptionsKey].source}</span>
+      <div className="flex items-center">
+        <span title={contextValue.config?.[sdkOptionsKey].source}>current sdk source: </span>
+        <select
+          value={
+            contextValue.config?.[sdkOptionsKey].source.match(/canary\.glean\.com|local\.glean\.com:8888/)
+              ? contextValue.config?.[sdkOptionsKey].source
+              : "custom"
+          }
+          onChange={(e) => {
+            contextValue.setConfig({
+              ...contextValue.config,
+              [sdkOptionsKey]: {
+                ...contextValue.config?.[sdkOptionsKey],
+                source: e.target.value
+              }
+            })
+          }}
+          name="sdk-source"
+          className="ml-2 mr-4 p-px rounded-md outline outline-1"
+        >
+          <option value="https://canary.glean.com/embedded-search-latest.min.js">Canary</option>
+          <option value="https://local.glean.com:8888/embedded-search-latest.min.js">Local</option>
+          <option value="custom" disabled>Custom</option>
+        </select>
         <button onClick={() => setSettingsOpen(true)} className="ml-auto">
-          <svg 
-            xmlns="http://www.w3.org/2000/svg" 
-            width="24" 
-            height="24" 
-            viewBox="0 0 24 24" 
-            fill="none" 
-            stroke="currentColor" 
-            strokeWidth="2" 
-            strokeLinecap="round" 
-            strokeLinejoin="round" 
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             className="feather feather-settings"
           >
             <circle cx="12" cy="12" r="3"></circle>

--- a/examples/browser-api-playground/src/components/Layout/Header.tsx
+++ b/examples/browser-api-playground/src/components/Layout/Header.tsx
@@ -1,9 +1,8 @@
 import { Menu, MenuProps, Layout } from "antd";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import SettingsDrawer from "../SettingsDrawer";
-import useConfigStore from "../../useConfigStore";
-import { sdkOptionsKey } from "../../EmbedConfigContext";
+import { EmbedConfigContext, sdkOptionsKey } from "../../EmbedConfigContext";
 
 const items: MenuProps['items'] = [
   {
@@ -25,14 +24,14 @@ const items: MenuProps['items'] = [
 ];
 
 const Header = () => {
-  const contextValue = useConfigStore()
+  const { config, setConfig } = useContext(EmbedConfigContext);
   const [settingsOpen, setSettingsOpen] = useState(false)
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const onClick: MenuProps['onClick'] = (e) => navigate(e.key);
 
   return (
-    <Layout.Header className="bg-white w-full flex items-center flex-grow-0 px-4 w-fixed w-full flex-shrink flex-grow-0 px-4 border-b border-gray-20 shadow-md">
+    <Layout.Header className="bg-white w-full flex items-center flex-grow-0 px-4 w-fixed w-full flex-shrink flex-grow-0 px-4 border-b border-gray-20 shadow-md justify-between">
       <Menu
         mode="horizontal"
         selectedKeys={[pathname]}
@@ -41,18 +40,18 @@ const Header = () => {
         style={{width: '85%'}}
       />
       <div className="flex items-center">
-        <span title={contextValue.config?.[sdkOptionsKey].source}>current sdk source: </span>
+        <span title={config?.[sdkOptionsKey].source}>current sdk source: </span>
         <select
           value={
-            contextValue.config?.[sdkOptionsKey].source.match(/canary\.glean\.com|local\.glean\.com:8888/)
-              ? contextValue.config?.[sdkOptionsKey].source
+            config?.[sdkOptionsKey].source.match(/canary\.glean\.com|local\.glean\.com:8888/)
+              ? config?.[sdkOptionsKey].source
               : "custom"
           }
           onChange={(e) => {
-            contextValue.setConfig({
-              ...contextValue.config,
+            setConfig({
+              ...config,
               [sdkOptionsKey]: {
-                ...contextValue.config?.[sdkOptionsKey],
+                ...config?.[sdkOptionsKey],
                 source: e.target.value
               }
             })


### PR DESCRIPTION
Typos when changing the source are an easy source of silly errors.

Added a `<select>` to choose Canary or Local. Displays "Custom" if the SDK source option is edited directly (for example, if local glean is not running on port 8888), but Custom is not user selectable. Current source still shown via hover over "current sdk source:" (though this is not obvious and can be improved later)

### Screenshots
<img width="296" height="70" alt="Screenshot 2025-08-11 at 1 59 51 PM" src="https://github.com/user-attachments/assets/80ebac30-48ee-4083-8c13-490e2c4cece9" />

---

<img width="286" height="107" alt="Screenshot 2025-08-11 at 2 01 43 PM" src="https://github.com/user-attachments/assets/dca97485-3a05-4cb9-8b3d-cf9167325d41" />

---

<img width="289" height="91" alt="Screenshot 2025-08-11 at 2 01 52 PM" src="https://github.com/user-attachments/assets/aa21a176-a3d9-4684-8fbf-db30cb87b12c" />
