### PR TITLE
Add UI to show the current chat location

### DIFF
--- a/examples/browser-api-playground/src/pages/ChatPage.tsx
+++ b/examples/browser-api-playground/src/pages/ChatPage.tsx
@@ -1,9 +1,14 @@
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { EmbedConfigContext, authOptionsKey, baseOptionsKey } from "../EmbedConfigContext";
 import { EmbeddedSearchWidget } from "../types";
 import useAuthProvider from "../useAuthProvider";
-import { ThemeVariant } from "@gleanwork/web-sdk";
+import { type ThemeVariant } from "@gleanwork/web-sdk";
+
+interface ChatLocation {
+  type: 'chat' | 'agent';
+  id: string | undefined;
+}
 
 const ChatPage = () => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -11,6 +16,7 @@ const ChatPage = () => {
   const {config} = useContext(EmbedConfigContext)
   const authParams = useAuthProvider(config[authOptionsKey], config[baseOptionsKey].backend)
   const navigate = useNavigate()
+  const [ currentChatLocation, setCurrentChatLocation ] = useState<ChatLocation | undefined>(undefined);
 
   useEffect(() => {
     if (!window.GleanWebSDK) return;
@@ -19,12 +25,20 @@ const ChatPage = () => {
       ...config[baseOptionsKey],
       ...config[EmbeddedSearchWidget.Chat]
     }
-    containerRef.current && window.GleanWebSDK.renderChat(containerRef.current, {
+
+    const handler = containerRef.current && window.GleanWebSDK.renderChat(containerRef.current, {
       chatId: searchParams.get("chatId") ?? "",
       ...chatCustomConfig,
       ...authParams,
       // Add overrides to the custom config here
       themeVariant: chatCustomConfig.themeVariant as ThemeVariant,
+    });
+
+    handler?.on('chat:location_update', ({name, type, id}) => {
+      setCurrentChatLocation({
+        type,
+        id,
+      });
     });
   }, [searchParams, setSearchParams, navigate, config, authParams]);
 
@@ -36,7 +50,9 @@ const ChatPage = () => {
         width: "100%",
         position: "relative",
       }}
-    />
+    >
+      <span className="text-sm rounded-md p-1 my-2 inline-block">Current {currentChatLocation?.type}: {String(currentChatLocation?.id)}</span>
+    </div>
   );
 };
 


### PR DESCRIPTION
Added some UI to test the `chat:location_update` event. UI now shows which chat/agent the user is viewing and its ID.

### Screenshots
**New chat (undefined)**
<img width="400" height="342" alt="Screenshot 2026-02-04 at 11 00 51 AM" src="https://github.com/user-attachments/assets/e0d5a713-a31b-4038-b398-06c071389141" />

---

**Chat ID**
<img width="399" height="348" alt="Screenshot 2026-02-04 at 11 01 05 AM" src="https://github.com/user-attachments/assets/4607be91-2d8d-421d-b25a-979e4877315f" />

---

**Agent ID**
<img width="397" height="351" alt="Screenshot 2026-02-04 at 11 01 19 AM" src="https://github.com/user-attachments/assets/c75d8de1-e7c8-4b79-8509-9079e2180df6" />
