### PR TITLE
Fix onChat

### DIFF
--- a/examples/browser-api-playground/src/pages/ChatPage.tsx
+++ b/examples/browser-api-playground/src/pages/ChatPage.tsx
@@ -31,7 +31,7 @@ const ChatPage = () => {
       ...authParams,
       // Add overrides to the custom config here
       themeVariant: chatCustomConfig.themeVariant as ThemeVariant,
-      chatId: searchParams.get("chatId") ?? "",
+      chatId: searchParams.get("chatId") ?? chatCustomConfig.chatId,
     });
 
     handler?.on('chat:location_update', ({name, type, id}) => {

--- a/examples/browser-api-playground/src/pages/ChatPage.tsx
+++ b/examples/browser-api-playground/src/pages/ChatPage.tsx
@@ -27,11 +27,11 @@ const ChatPage = () => {
     }
 
     const handler = containerRef.current && window.GleanWebSDK.renderChat(containerRef.current, {
-      chatId: searchParams.get("chatId") ?? "",
       ...chatCustomConfig,
       ...authParams,
       // Add overrides to the custom config here
       themeVariant: chatCustomConfig.themeVariant as ThemeVariant,
+      chatId: searchParams.get("chatId") ?? "",
     });
 
     handler?.on('chat:location_update', ({name, type, id}) => {


### PR DESCRIPTION
`chatId` was being clobbered by other chatOptions, which meant that
* Transitioning from search to chat is broken in CSB
* linking to a chat via `?chatId=<id>` was also broken.

Now they  both work

https://github.com/user-attachments/assets/90720ebb-f9b7-4719-bf35-6b17c08e2634

<img width="1728" height="1002" alt="Screenshot 2026-04-08 at 1 02 38 PM" src="https://github.com/user-attachments/assets/efc4f0d2-cf47-4587-86bb-8864acd31376" />
